### PR TITLE
Clarify MinGW64 build commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ On MacOS, add `AppKit` to the list of frameworks.
 ### Windows
 On Windows, ensure you are building against `comctl32.lib` and `uuid.lib`.
 
+### MinGW
+Under MinGW64, ensure you are building against `ole32.lib` and `uuid.lib`.
+
 # Usage
 
 See `NFD.h` for API calls.  See the `test` directory for example code (both C and C++).


### PR DESCRIPTION
To build under MSYS2 + MinGW64 with `-lcomctl32 -luuid` fails with `undefined reference to `__imp_CoInitializeEx` and similar linking errors.
```
C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/11.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: C:\msys64\tmp\cc4PrAbe.ltrans0.ltrans.o:C:/msys64/home/Bayonetta2.0/new-horizon/lbs/nativefiledialog-extended/src/nfd_win.cpp:309: undefined reference to `__imp_CoInitializeEx'
C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/11.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: C:\msys64\tmp\cc4PrAbe.ltrans0.ltrans.o:C:/msys64/home/Bayonetta2.0/new-horizon/lbs/nativefiledialog-extended/src/nfd_win.cpp:340: undefined reference to `__imp_CoCreateInstance'
C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/11.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: C:\msys64\tmp\cc4PrAbe.ltrans0.ltrans.o:C:/msys64/home/Bayonetta2.0/new-horizon/lbs/nativefiledialog-extended/src/nfd_win.cpp:330: undefined reference to `__imp_CoTaskMemFree'
collect2.exe: error: ld returned 1 exit status
```
Instead building with `-lole32 -luuid` solves everything. By my logic, the build info for Windows should be changed as well, but I didn't test that and I don't now enough about the Windows SDK to understand why ole32 is needed but not comctl32.
Otherwise, works great <3