### PR TITLE
Remove seemingly forgotten line in nfd.h

### DIFF
--- a/src/include/nfd.h
+++ b/src/include/nfd.h
@@ -43,8 +43,6 @@ typedef struct {
     const nfdnchar_t* spec;
 } nfdnfilteritem_t;
 
-/* nfd_<targetplatform>.c */
-
 /* free a file path that was returned by the dialogs */
 /* Note: use NFD_PathSet_FreePath to free path from pathset instead of this function */
 void NFD_FreePathN(nfdnchar_t* filePath);


### PR DESCRIPTION
In nfd.h the line commented out line `/* nfd_<targetplatform>.c */` seems to serve no purpose, especially considering the target plattform is configured at buildtime.